### PR TITLE
Add Tags to bills

### DIFF
--- a/cli.thor
+++ b/cli.thor
@@ -23,13 +23,17 @@ class BeanCounterCli < Thor
             input = CLI::UI.ask('Enter the new value', default: (bill[opt]).to_s)
             # add in logic to skip transaction if value didn't change
             # input will be a string by default, need it to be and integer for amount and date_number
-            input = input.to_i unless opt == 'name'
+            input = input.to_i if opt == 'amount'
             # all operations on store need to happen in a transaction
             # All of this happens or none of it
             store.transaction do
               bill_index = store[bill_type].index(bill)
               # update the correct field in the YAML file
-              store[bill_type][bill_index][opt] = input
+              if opt == 'tags'
+                store[bill_type][bill_index][opt].push(input)
+              else
+                store[bill_type][bill_index][opt] = input
+              end 
               # implicitly return the updated bill
               store[bill_type][bill_index]
             end
@@ -39,32 +43,35 @@ class BeanCounterCli < Thor
     end
   end
 
-  desc 'list_categories', 'List all of the main bill categories you have set up'
+  # TODO: is this really necessary?
 
-  def list_categories
-    # type will be an array with the first element being the name of the category
-    BeanCounter.new.bills.each do |type|
-      puts type[0]
-    end
-  end
+  # desc 'list_categories', 'List all of the main bill categories you have set up'
+  #
+  # def list_categories
+  #   # type will be an array with the first element being the name of the category
+  #   BeanCounter.new.bills.each do |type|
+  #     puts type[0]
+  #   end
+  # end
 
-  desc 'list_bills', 'Choose a category and see all the bills it contains'
-
-  def list_bills
-    app = BeanCounter.new
-    selection = ''
-    CLI::UI::StdoutRouter.enable
-    CLI::UI::Prompt.ask('Choose a category to display') do |handler|
-      handler.option('all') { |_opt| app.display_bills_by_category('all') }
-      handler.option('monthly bills') { |_opt| app.display_bills_by_category('monthly_bills') }
-      handler.option('credit cards') { |_opt| app.display_bills_by_category('credit_cards') }
-      handler.option('every check') { |_opt| app.display_bills_by_category('every_check') }
-    end
-  end
+#   desc 'list_bills', 'Choose a category and see all the bills it contains'
+#
+# # TODO: make this work with tags
+#   def list_bills
+#     app = BeanCounter.new
+#     CLI::UI::StdoutRouter.enable
+#     CLI::UI::Prompt.ask('Choose a category to display') do |handler|
+#       handler.option('all') { |_opt| app.display_bills_by_category('all') }
+#       handler.option('monthly bills') { |_opt| app.display_bills_by_category('monthly_bills') }
+#       handler.option('credit cards') { |_opt| app.display_bills_by_category('credit_cards') }
+#       handler.option('every check') { |_opt| app.display_bills_by_category('every_check') }
+#     end
+#   end
 
   desc 'list_bills_in_period START_DATE',
        'Lists bills that are due between START_DATE and END_DATE. dates must be in format yyyy-mm-dd'
-
+  
+  # TODO: refactor this to use an end date
   def list_bills_in_period(date)
     app = BeanCounter.new(date)
     app.display_bills_in_period

--- a/cli.thor
+++ b/cli.thor
@@ -54,19 +54,19 @@ class BeanCounterCli < Thor
   #   end
   # end
 
-#   desc 'list_bills', 'Choose a category and see all the bills it contains'
-#
-# # TODO: make this work with tags
-#   def list_bills
-#     app = BeanCounter.new
-#     CLI::UI::StdoutRouter.enable
-#     CLI::UI::Prompt.ask('Choose a category to display') do |handler|
-#       handler.option('all') { |_opt| app.display_bills_by_category('all') }
-#       handler.option('monthly bills') { |_opt| app.display_bills_by_category('monthly_bills') }
-#       handler.option('credit cards') { |_opt| app.display_bills_by_category('credit_cards') }
-#       handler.option('every check') { |_opt| app.display_bills_by_category('every_check') }
-#     end
-#   end
+  desc 'list_bills', 'Choose a category and see all the bills it contains'
+
+  def list_bills
+    app = BeanCounter.new
+    CLI::UI::StdoutRouter.enable
+    CLI::UI::Prompt.ask('Choose a category to display') do |handler|
+      handler.option('all') { |_opt| app.display_bills_by_tag('all') }
+      app.tags.each do |tag|
+        handler.option(tag) { |_opt| app.display_bills_by_tag(tag) }
+      end
+
+    end
+  end
 
   desc 'list_bills_in_period START_DATE',
        'Lists bills that are due between START_DATE and END_DATE. dates must be in format yyyy-mm-dd'

--- a/lib/bean_counter.rb
+++ b/lib/bean_counter.rb
@@ -10,7 +10,8 @@ require 'pry-byebug'
 # Contains core business logic for CLI functionality
 class BeanCounter
   include Display
-  attr_accessor :bills, :config, :pay_range, :start_date, :date_range, :paycheck, :divisions, :net_income, :messages
+  attr_accessor :bills, :config, :pay_range, :start_date, :date_range, :paycheck, :divisions, :net_income, :messages,
+                :tags
 
   def initialize(date = Date.today.to_s)
     @bill_path = 'config/bills.yml'
@@ -25,6 +26,7 @@ class BeanCounter
     @date_range = @start_date..(@start_date + @pay_range)
     @divisions = @config['dividing_rules']
     @messages = messages_in_period
+    @tags = collect_tags
   end
 
   # iterate through each bill group, then iterate through each bill in that group
@@ -115,5 +117,11 @@ class BeanCounter
 
     # only push messages to the memo array if their associated date is within the current date range
     all_messages.filter { |mess| @date_range.include?(Date.parse(mess['date'])) }
+  end
+
+  private
+
+  def collect_tags
+    @bills.values.flatten.each_with_object([]) { |bill, obj| obj.push(bill['tags']) }.flatten.uniq
   end
 end

--- a/lib/bean_counter.rb
+++ b/lib/bean_counter.rb
@@ -53,7 +53,6 @@ class BeanCounter
     end
 
     # create an array of all the bills with due dates in the date range
-    # TODO: extract logic to filter the fills
     bills.values.flatten.select do |bill|
       bill['date'].to_s == 'every_check' || date_numbers.include?(bill['date'])
     end
@@ -107,7 +106,10 @@ class BeanCounter
 
   # Returns hash: {date:string => body:string}
   # each string being a message body
+  # TODO: automate message.yml creation
   def messages_in_period
+    return File.new('./config/messages.yml', 'w+') unless File.exist?('./config/messages.yml')
+
     all_messages = YAML.load_file(@messages_path)['messages']
     return [] if all_messages.nil?
 

--- a/lib/bean_counter.rb
+++ b/lib/bean_counter.rb
@@ -54,10 +54,9 @@ class BeanCounter
 
     # create an array of all the bills with due dates in the date range
     # TODO: extract logic to filter the fills
-    bills_to_pay = (bills['monthly_bills'] + bills['credit_cards']).select do |bill|
-      date_numbers.include?(bill['date_number'])
+    bills.values.flatten.select do |bill|
+      bill['date'].to_s == 'every_check' || date_numbers.include?(bill['date'])
     end
-    bills_to_pay + bills['every_check']
   end
 
   def sum_bills(bill_arr)

--- a/lib/bean_counter.rb
+++ b/lib/bean_counter.rb
@@ -54,7 +54,7 @@ class BeanCounter
 
     # create an array of all the bills with due dates in the date range
     bills.values.flatten.select do |bill|
-      bill['date'].to_s == 'every_check' || date_numbers.include?(bill['date'])
+      bill['tags'].include?('every check') || date_numbers.include?(bill['date'])
     end
   end
 

--- a/lib/display.rb
+++ b/lib/display.rb
@@ -19,6 +19,7 @@ module Display
 
   def display_bills(bill_arr, title)
     CLI::UI::StdoutRouter.enable
+
     CLI::UI::Frame.open(title) do
       bill_arr.each do |bill|
         display_bill(bill)
@@ -27,12 +28,12 @@ module Display
   end
 
   def display_bill(bill)
-    display_string = 'Name:'.red + " #{bill['name']}, " + 'Amount Due:'.blue + " #{bill['amount']}"
-    display_string += if bill['date_number']
-                        ' Date:'.yellow + " #{bill['date_number']}"
-                      else
-                        "#{' Date:'.yellow} Pay every check"
-                      end
+    display_string = 'Name:'.red +
+                     " #{bill['name']}, " +
+                     'Amount Due:'.blue +
+                     " #{bill['amount']}" +
+                     ' Date:'.yellow +
+                     " #{bill['date']}"
     puts display_string
   end
 

--- a/lib/display.rb
+++ b/lib/display.rb
@@ -7,13 +7,14 @@ module Display
     display_bills(gather_bills_in_period, date_range.to_s)
   end
 
-  def display_bills_by_category(cat)
-    if cat == 'all'
+  def display_bills_by_tag(tag)
+    if tag == 'all'
       bills.each do |type, bill_list|
         display_bills(bill_list, type)
       end
     else
-      display_bills(bills[cat], cat)
+      tagged_bills = bills.values.flatten.select { |b| b['tags'].include?(tag) }
+      display_bills(tagged_bills, tag)
     end
   end
 


### PR DESCRIPTION
Refactor bills to remove sections and introduce a tags attribute. Allows bills to be set to 'every check' by adding that tag. Bills can now be filtered by tag, which they can have multiple of. Tags can also be added to with the edit_bills command.

also includes changes to thor commands and display methods to accommodate the addition of tags  